### PR TITLE
58 document how to get a working local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TekClinic
 
-For setup, go to [setup](setup.md)
+For setup, go to [setup](setup.md).
 
 TekClinic is a web platform for clinic management that is made to serve “New Spirit” - a community clinic at the Keranot
 House in Haifa.
@@ -10,7 +10,7 @@ The platform includes tools to efficiently manage patients, doctors, and appoint
 The platform is built and maintained by students of the Yearly Software Engineering Project (02340311 + 02340312) in the
 Computer Science faculty of the Technion.
 
-## Developers:
+## Developers
 
 ### First Iteration
 
@@ -23,6 +23,20 @@ Computer Science faculty of the Technion.
 - [@nikolro](https://github.com/nikolro)
 - [@Tal-Dahan](https://github.com/Tal-Dahan)
 - [@DanaMel8](https://github.com/DanaMel8)
+
+**Supervisor**:
+[@vMaroon](https://github.com/vMaroon)
+
+### Second Iteration
+
+**Students**:
+
+- [@yonatan-reicher](https://github.com/yonatan-reicher)
+- [@UriKH](https://github.com/UriKH)
+- Daria
+- Matan Biton
+- Erel Hadad
+- Ron Velitzky
 
 **Supervisor**:
 [@vMaroon](https://github.com/vMaroon)

--- a/setup.md
+++ b/setup.md
@@ -1,18 +1,18 @@
 # Installation & Setup
 
-- Download [Node.js](https://nodejs.org/en)
+1. Download [Node.js](https://nodejs.org/en)
 
-- try to run the command `npm` in the terminal. If it says `command not found`, make sure npm is added to the path- [click here](https://phoenixnap.com/kb/npm-command-not-found) and follow the tutorial.
+2. Try to run the command `npm` in the terminal. If it says `command not found`, make sure npm is added to the path- [click here](https://phoenixnap.com/kb/npm-command-not-found) and follow the tutorial.
 
-- clone the github repo with `git clone "https://github.com/TekClinic/TekClinic-Web-App"`
+3. Clone the GitHub repo with `git clone "https://github.com/TekClinic/TekClinic-Web-App"`
 
-- run `npm install` and wait until the installation is over
+4. Run `npm install` and wait until the installation is over
 
-- create a `.env.local` file in the root directory (where the `package.json` file is) and add the following content:
+5. Create a `.env.local` file in the root directory (where the `package.json` file is) and add the following content:
 ```env
 NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_API_KEY=YOUR_API_KEY
 NEXT_PUBLIC_SYNCFUSION_LICENSE_KEY=a
 ```
 
-- run `npm run dev` to start the website locally, it should run at `http://localhost:3000/`
+6. Run `npm run dev` to start the website locally, it should run at `http://localhost:3000/`

--- a/setup.md
+++ b/setup.md
@@ -1,18 +1,31 @@
 # Installation & Setup
 
-1. Download [Node.js](https://nodejs.org/en)
+## Prerequisites
 
-2. Try to run the command `npm` in the terminal. If it says `command not found`, make sure npm is added to the path- [click here](https://phoenixnap.com/kb/npm-command-not-found) and follow the tutorial.
+- **Node.js** 
+  You can download it on [nodejs.org](https://nodejs.org/en).
+  Try to run the command `npm` in the terminal.
+  If it says `command not found`, make sure npm is added to the path-
+  [click here](https://phoenixnap.com/kb/npm-command-not-found) and follow the
+  tutorial.
 
-3. Clone the GitHub repo with `git clone "https://github.com/TekClinic/TekClinic-Web-App"`
+- **`.env.local` file**  
+  This file holds sensitive API keys. Do not upload it anywhere!
+  Copy it from someone else on the team.
 
-4. Run `npm install` and wait until the installation is over
+## Setup
 
-5. Create a `.env.local` file in the root directory (where the `package.json` file is) and add the following content:
-```env
-NEXT_PUBLIC_API_URL=http://localhost:3000
-NEXT_PUBLIC_API_KEY=YOUR_API_KEY
-NEXT_PUBLIC_SYNCFUSION_LICENSE_KEY=a
-```
+1. Clone the GitHub repo with `git clone "https://github.com/TekClinic/TekClinic-Web-App"`
 
-6. Run `npm run dev` to start the website locally, it should run at `http://localhost:3000/`
+2. Run `npm install` and wait until the installation is over
+
+3. Copy `.env.local` file in the root directory (where the `package.json`
+   file is).
+
+4. Open the setup repo and start all the services.
+
+5. Run `npm run dev` to start the website locally, it should run at
+   `http://localhost:3000/`.
+   This command starts the website in development mode, allowing you to see
+   changes you make to the code in real-time (How cool is that?).
+

--- a/setup.md
+++ b/setup.md
@@ -1,18 +1,18 @@
-
 # Installation & Setup
 
 - Download [Node.js](https://nodejs.org/en)
 
-![Alt text](image.png)
-
 - try to run the command `npm` in the terminal. If it says `command not found`, make sure npm is added to the path- [click here](https://phoenixnap.com/kb/npm-command-not-found) and follow the tutorial.
 
-- create a new **local** folder.
-
-- cd into the folder `cd path/to/the/new/folder`
-
-- clone the github repo with `github clone <url>`
+- clone the github repo with `git clone "https://github.com/TekClinic/TekClinic-Web-App"`
 
 - run `npm install` and wait until the installation is over
+
+- create a `.env.local` file in the root directory (where the `package.json` file is) and add the following content:
+```env
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_API_KEY=YOUR_API_KEY
+NEXT_PUBLIC_SYNCFUSION_LICENSE_KEY=a
+```
 
 - run `npm run dev` to start the website locally, it should run at `http://localhost:3000/`

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css'
 import React from 'react'
 
 import {
+  Anchor,
   AppShell,
   Burger,
   Center,
@@ -139,7 +140,8 @@ function ContentLayout ({ children }: {
                 color: '#888',
                 fontSize: '17px'
               }}>
-                built by team 8
+                built by <Anchor href="https://github.com/TekClinic" target="_blank">students of the Computer Science
+                faculty of the Technion</Anchor>
               </div>
             </Center>
           </AppShell.Footer>


### PR DESCRIPTION
Updated setup information to contain all the relevant info. Changes make it clear that:
- `setup.md` exists (linked in the README.md)
- You need `.env.local` and it is secret.
- You can use `npm run dev` to run locally, but you still need to launch all the other servers.

Closes #58 .