### PR TITLE
Doctors can see all appoinment for the patient in it's card (in the patients page's table)

### DIFF
--- a/src/api/model/appointment.ts
+++ b/src/api/model/appointment.ts
@@ -57,6 +57,7 @@ export class Appointment {
     return `Dr. ${doctorName} available`
   }
 
+  /** If the doctor is loaded, returns the doctor's name, otherwise returns the doctor ID. */
   getDoctorName = (): string => {
     return this.doctor?.name ?? this.doctor_id.toString()
   }

--- a/src/app/patients/ViewPatient.tsx
+++ b/src/app/patients/ViewPatient.tsx
@@ -1,65 +1,162 @@
 import React from 'react'
-import { Avatar, Badge, Box, Divider, Group, Text, Stack, MantineColorScheme } from '@mantine/core'
+import { type Session } from 'next-auth'
+import { Avatar, Badge, Box, Divider, Group, Text, Stack, type MantineColorScheme, Paper } from '@mantine/core'
 import { type Patient } from '@/src/api/model/patient'
 import male_avatar from '@/public/male-patient.webp'
 import female_avatar from '@/public/female-patient.webp'
 import unknown_avatar from '@/public/unknown-patient.webp'
+import { Appointment } from '@/src/api/model/appointment'
+
+async function loadPatientAppointments (patientId: number, session: Session): Promise<Appointment[]> {
+  const { items: appointments } = await Appointment.get({
+    patient_id: patientId
+  }, session)
+  return appointments
+}
+
+function padTwoDigits (num: number): string {
+  return num.toString().padStart(2, '0')
+}
+
+const AppointmentDate: React.FC<{ date: Date }> = ({ date }) => {
+  return `${padTwoDigits(date.getDate())}-${padTwoDigits(date.getMonth())}-${date.getFullYear()}`
+}
+
+const AppointmentTime: React.FC<{ date: Date }> = ({ date }) => {
+  return `${padTwoDigits(date.getHours())}:${padTwoDigits(date.getMinutes())}`
+}
+
+const ViewAppointment: React.FC<{ appointment: Appointment, session: Session }> = ({ appointment, session }) => {
+  const [doctorName, setDoctorName] = React.useState<string | null>(null)
+  const [error, setError] = React.useState(false)
+
+  // Need to load the doctor to read it's name.
+  React.useEffect(() => {
+    appointment.loadDoctor(session)
+      .then(() => { setDoctorName(appointment.getDoctorName()) })
+      .catch(() => { setError(true) })
+  }, [appointment, session])
+
+  const { start_time: startTime, end_time: endTime } = appointment
+
+  // Paper is like a div with a shadow and a border.
+  // TODO: What if the end_timee is on a different day?
+  return <Box component="span">
+    <AppointmentDate date={startTime} /> <AppointmentTime date={startTime} /> - <AppointmentTime date={endTime} />
+    <Paper
+      shadow="md"
+      mb="xs"
+      withBorder
+      bg="lime"
+    >
+      {doctorName ?? (error ? 'Could not load doctor' : 'Loading name...')}
+    </Paper>
+  </Box>
+}
+
+/**
+ * This renders a list of appointments for a given patient, to be shown in the
+ * patient view below the patient's information.
+ */
+const ViewPatientAppointments: React.FC<{ patientId: number, session: Session }> = ({ patientId, session }) => {
+  const [appointments, setAppointments] = React.useState<Appointment[] | null>(null)
+  const [error, setError] = React.useState(false)
+
+  // Load appointments then update the state.
+  React.useEffect(() => {
+    loadPatientAppointments(patientId, session)
+      .then(appointments => { setAppointments(appointments) })
+      .catch(() => { setError(true) })
+  }, [patientId, session])
+
+  if (appointments === null) {
+    return <Text>Loading appointments...</Text>
+  }
+
+  if (error) {
+    return <Text>Error loading appointments.</Text>
+  }
+
+  return <Box>
+    {appointments.map(appointment =>
+      <ViewAppointment appointment={appointment} session={session} key={appointment.id} />
+    )}
+    {appointments.map(appointment =>
+      <ViewAppointment appointment={appointment} session={session} key={appointment.id} />
+    )}
+    {appointments.map(appointment =>
+      <ViewAppointment appointment={appointment} session={session} key={appointment.id} />
+    )}
+    {appointments.map(appointment =>
+      <ViewAppointment appointment={appointment} session={session} key={appointment.id} />
+    )}
+  </Box>
+}
 
 interface ViewPatientProps {
-    computedColorScheme: MantineColorScheme,
-    patient: Patient
+  computedColorScheme: MantineColorScheme
+  patient: Patient
+  session: Session
 }
 
 const ViewPatient: React.FC<ViewPatientProps> =
   ({
+    session,
     computedColorScheme,
-    patient,
-  }) => 
-  <Group align="flex-start">
-    <Avatar size={120} radius="120px"
-            src={patient.gender === 'male' ? male_avatar.src : patient.gender === 'female' ? female_avatar.src : unknown_avatar.src}
-            alt="Patient photo"/>
-    <Stack>
-      <Box>
-        <Text><strong>Name:</strong> {patient.name}</Text>
-        <Text><strong>Age:</strong> {patient.age}</Text>
-        <Text><strong>Gender:</strong> {patient.gender}</Text>
-        {patient.phone_number !== null && <Text><strong>Phone:</strong> {patient.phone_number}</Text>}
-        <Text><strong>Birth Date:</strong> {patient.birth_date.toLocaleDateString()}</Text>
+    patient
+  }) =>
+  <Box>
+    <Group align="flex-start">
+      <Avatar size={120} radius="120px"
+              src={patient.gender === 'male' ? male_avatar.src : patient.gender === 'female' ? female_avatar.src : unknown_avatar.src}
+              alt="Patient photo"/>
+      <Stack>
+        <Box>
+          <Text><strong>Name:</strong> {patient.name}</Text>
+          <Text><strong>Age:</strong> {patient.age}</Text>
+          <Text><strong>Gender:</strong> {patient.gender}</Text>
+          {patient.phone_number !== null && <Text><strong>Phone:</strong> {patient.phone_number}</Text>}
+          <Text><strong>Birth Date:</strong> {patient.birth_date.toLocaleDateString()}</Text>
 
-        <Text><strong>Languages:</strong></Text>
+          <Text><strong>Languages:</strong></Text>
 
-        {patient.languages.map((language) => (
-            <Badge key={language} variant="gradient" gradient={{
-              from: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
-              to: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
-              deg: 90
-            }} style={{ color: computedColorScheme === 'light' ? 'black' : 'white' }}>
-              {language}
-            </Badge>
-        )
-        )}
+          {patient.languages.map((language) => (
+              <Badge key={language} variant="gradient" gradient={{
+                from: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
+                to: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
+                deg: 90
+              }} style={{ color: computedColorScheme === 'light' ? 'black' : 'white' }}>
+                {language}
+              </Badge>
+          )
+          )}
 
-        {patient.referred_by !== null && <Text><strong>Referred By:</strong> {patient.referred_by}</Text>}
-        {patient.special_note !== null &&
-            <Text><strong>Special Note:</strong> {patient.special_note}</Text>}
-      </Box>
+          {patient.referred_by !== null && <Text><strong>Referred By:</strong> {patient.referred_by}</Text>}
+          {patient.special_note !== null &&
+              <Text><strong>Special Note:</strong> {patient.special_note}</Text>}
+        </Box>
 
-      {patient.emergency_contacts.length !== 0 && <Divider my="sm"/>}
+        {patient.emergency_contacts.length !== 0 && <Divider my="sm"/>}
 
-      <Box>
-        {patient.emergency_contacts.length !== 0 && <Text><strong>Emergency Contacts:</strong></Text>}
-        <Stack>
-          {patient.emergency_contacts.map((contact, index) => (
-            <Box key={index}>
-              <Text><strong>Name:</strong> {contact.name}</Text>
-              <Text><strong>Relation:</strong> {contact.closeness}</Text>
-              <Text><strong>Phone:</strong> {contact.phone}</Text>
-            </Box>
-          ))}
-        </Stack>
-      </Box>
-    </Stack>
-  </Group>
-  
+        <Box>
+          {patient.emergency_contacts.length !== 0 && <Text><strong>Emergency Contacts:</strong></Text>}
+          <Stack>
+            {patient.emergency_contacts.map((contact, index) => (
+              <Box key={index}>
+                <Text><strong>Name:</strong> {contact.name}</Text>
+                <Text><strong>Relation:</strong> {contact.closeness}</Text>
+                <Text><strong>Phone:</strong> {contact.phone}</Text>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+
+      </Stack>
+    </Group>
+
+    <Divider my="sm"/>
+
+    <ViewPatientAppointments patientId={patient.id} session={session} />
+  </Box>
+
 export default ViewPatient

--- a/src/app/patients/ViewPatient.tsx
+++ b/src/app/patients/ViewPatient.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Avatar, Badge, Box, Divider, Group, Text, Stack, MantineColorScheme } from '@mantine/core'
+import { type Patient } from '@/src/api/model/patient'
+import male_avatar from '@/public/male-patient.webp'
+import female_avatar from '@/public/female-patient.webp'
+import unknown_avatar from '@/public/unknown-patient.webp'
+
+interface ViewPatientProps {
+    computedColorScheme: MantineColorScheme,
+    patient: Patient
+}
+
+const ViewPatient: React.FC<ViewPatientProps> =
+  ({
+    computedColorScheme,
+    patient,
+  }) => 
+  <Group align="flex-start">
+    <Avatar size={120} radius="120px"
+            src={patient.gender === 'male' ? male_avatar.src : patient.gender === 'female' ? female_avatar.src : unknown_avatar.src}
+            alt="Patient photo"/>
+    <Stack>
+      <Box>
+        <Text><strong>Name:</strong> {patient.name}</Text>
+        <Text><strong>Age:</strong> {patient.age}</Text>
+        <Text><strong>Gender:</strong> {patient.gender}</Text>
+        {patient.phone_number !== null && <Text><strong>Phone:</strong> {patient.phone_number}</Text>}
+        <Text><strong>Birth Date:</strong> {patient.birth_date.toLocaleDateString()}</Text>
+
+        <Text><strong>Languages:</strong></Text>
+
+        {patient.languages.map((language) => (
+            <Badge key={language} variant="gradient" gradient={{
+              from: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
+              to: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
+              deg: 90
+            }} style={{ color: computedColorScheme === 'light' ? 'black' : 'white' }}>
+              {language}
+            </Badge>
+        )
+        )}
+
+        {patient.referred_by !== null && <Text><strong>Referred By:</strong> {patient.referred_by}</Text>}
+        {patient.special_note !== null &&
+            <Text><strong>Special Note:</strong> {patient.special_note}</Text>}
+      </Box>
+
+      {patient.emergency_contacts.length !== 0 && <Divider my="sm"/>}
+
+      <Box>
+        {patient.emergency_contacts.length !== 0 && <Text><strong>Emergency Contacts:</strong></Text>}
+        <Stack>
+          {patient.emergency_contacts.map((contact, index) => (
+            <Box key={index}>
+              <Text><strong>Name:</strong> {contact.name}</Text>
+              <Text><strong>Relation:</strong> {contact.closeness}</Text>
+              <Text><strong>Phone:</strong> {contact.phone}</Text>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </Stack>
+  </Group>
+  
+export default ViewPatient

--- a/src/app/patients/page.tsx
+++ b/src/app/patients/page.tsx
@@ -3,15 +3,13 @@
 import dayjs from 'dayjs'
 import React from 'react'
 import { Patient } from '@/src/api/model/patient'
-import { Avatar, Badge, Box, Divider, Flex, Group, Stack, Text, useComputedColorScheme } from '@mantine/core'
+import { Badge, Flex, useComputedColorScheme } from '@mantine/core'
 import CustomTable from '@/src/components/CustomTable'
 import { buildDeleteModal } from '@/src/utils/modals'
 import { modals } from '@mantine/modals'
-import CreatePatientForm from '@/src/app/patients/CreatePatientForm'
+import CreatePatientForm from './CreatePatientForm'
 import EditPatientForm from './EditPatientForm'
-import male_avatar from '@/public/male-patient.webp'
-import female_avatar from '@/public/female-patient.webp'
-import unknown_avatar from '@/public/unknown-patient.webp'
+import ViewPatient from './ViewPatient'
 
 function PatientsPage (): React.JSX.Element {
   const computedColorScheme = useComputedColorScheme()
@@ -78,61 +76,20 @@ function PatientsPage (): React.JSX.Element {
       }
       showViewModal={
         ({
-          item,
+          item: patient,
           computedColorScheme
         }) => {
-          const patient = item
+          // Generate some random modal id
+          const modalId = 'view-patient-modal'
           modals.open({
+            modalId,
             title: 'Patient Information',
             centered: true,
-            children: (
-              <Group align="flex-start">
-                <Avatar size={120} radius="120px"
-                        src={patient.gender === 'male' ? male_avatar.src : patient.gender === 'female' ? female_avatar.src : unknown_avatar.src}
-                        alt="Patient photo"/>
-                <Stack>
-                  <Box>
-                    <Text><strong>Name:</strong> {patient.name}</Text>
-                    <Text><strong>Age:</strong> {patient.age}</Text>
-                    <Text><strong>Gender:</strong> {patient.gender}</Text>
-                    {patient.phone_number !== null && <Text><strong>Phone:</strong> {patient.phone_number}</Text>}
-                    <Text><strong>Birth Date:</strong> {patient.birth_date.toLocaleDateString()}</Text>
-
-                    <Text><strong>Languages:</strong></Text>
-
-                    {patient.languages.map((language) => (
-                        <Badge key={language} variant="gradient" gradient={{
-                          from: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
-                          to: (computedColorScheme === 'light' ? '#e3e3e3' : '#3d3c3c'),
-                          deg: 90
-                        }} style={{ color: computedColorScheme === 'light' ? 'black' : 'white' }}>
-                          {language}
-                        </Badge>
-                    )
-                    )}
-
-                    {patient.referred_by !== null && <Text><strong>Referred By:</strong> {patient.referred_by}</Text>}
-                    {patient.special_note !== null &&
-                        <Text><strong>Special Note:</strong> {patient.special_note}</Text>}
-                  </Box>
-
-                  {patient.emergency_contacts.length !== 0 && <Divider my="sm"/>}
-
-                  <Box>
-                    {patient.emergency_contacts.length !== 0 && <Text><strong>Emergency Contacts:</strong></Text>}
-                    <Stack>
-                      {patient.emergency_contacts.map((contact, index) => (
-                        <Box key={index}>
-                          <Text><strong>Name:</strong> {contact.name}</Text>
-                          <Text><strong>Relation:</strong> {contact.closeness}</Text>
-                          <Text><strong>Phone:</strong> {contact.phone}</Text>
-                        </Box>
-                      ))}
-                    </Stack>
-                  </Box>
-                </Stack>
-              </Group>
-            )
+            children:
+              <ViewPatient
+                computedColorScheme={computedColorScheme}
+                patient={patient}
+              />
           })
         }
       }

--- a/src/app/patients/page.tsx
+++ b/src/app/patients/page.tsx
@@ -76,6 +76,7 @@ function PatientsPage (): React.JSX.Element {
       }
       showViewModal={
         ({
+          session,
           item: patient,
           computedColorScheme
         }) => {
@@ -87,6 +88,7 @@ function PatientsPage (): React.JSX.Element {
             centered: true,
             children:
               <ViewPatient
+                session={session}
                 computedColorScheme={computedColorScheme}
                 patient={patient}
               />

--- a/src/app/patients/page.tsx
+++ b/src/app/patients/page.tsx
@@ -84,7 +84,7 @@ function PatientsPage (): React.JSX.Element {
           const modalId = 'view-patient-modal'
           modals.open({
             modalId,
-            title: 'Patient Information',
+            title: `Patient ${patient.name}`,
             centered: true,
             children:
               <ViewPatient

--- a/src/components/CustomTable.tsx
+++ b/src/components/CustomTable.tsx
@@ -28,6 +28,7 @@ const pageSizeOptions = [2, 5, 10, 20, 50]
 interface BaseModalProps {
   session: Session
   computedColorScheme: MantineColorScheme
+  /** Await this function when successfully finished with the modal. */
   onSuccess: () => Promise<void>
 }
 


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the patient view and appointment handling in the application. Extracted the patient card to a new `ViewPatient` component, and the new component shows all appointments related to the patient *in a list view*.

Patient name also appears in the new card's title (so you don't need to remember when scrolling the appointments).

Also, added a doc comment in Appointment.getDoctorName and onSuccess in CustomTable.