### PR TITLE
Add Dashboard pages

### DIFF
--- a/src/app/dashboard/create-appointment/page.tsx
+++ b/src/app/dashboard/create-appointment/page.tsx
@@ -1,0 +1,3 @@
+export default function Page () {
+    return <div>pageegaegeapeage</div>
+}

--- a/src/app/dashboard/create-appointment/page.tsx
+++ b/src/app/dashboard/create-appointment/page.tsx
@@ -1,3 +1,25 @@
+'use client'
+
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation';
+import {
+    Button,
+    Title,
+    Stack,
+} from '@mantine/core'
+
+
 export default function Page () {
-    return <div>pageegaegeapeage</div>
+    const params = useSearchParams();
+    const patient = params.get("patient");
+    return <Stack>
+        <Title ta="center">Create an Appointment for {patient}</Title>
+        <Link prefetch={true} href={{
+            pathname: "/dashboard/view-patient",
+            query: { patient, appointment: "test-appointment" }
+        }}>
+            <Button fullWidth>New appointment for a test patient</Button>
+        </Link>
+    </Stack>
 }

--- a/src/app/dashboard/create-patient/page.tsx
+++ b/src/app/dashboard/create-patient/page.tsx
@@ -1,0 +1,3 @@
+export default function CreatePatientPage () {
+    return 'aarstar'
+}

--- a/src/app/dashboard/create-patient/page.tsx
+++ b/src/app/dashboard/create-patient/page.tsx
@@ -1,3 +1,21 @@
+import Link from 'next/link'
+import {
+    Button,
+    Title,
+    Stack,
+} from '@mantine/core'
+
+
 export default function CreatePatientPage () {
-    return 'aarstar'
+    return <Stack>
+        <Title ta="center">Create a Patient</Title>
+        {/* Here we might show the exact same form from the CreatePatient Modal
+        */}
+        <Link prefetch={true} href={{
+            pathname: "/dashboard/create-appointment",
+            query: { patient: "test-patient" }
+        }}>
+            <Button fullWidth>New appointment for a test patient</Button>
+        </Link>
+    </Stack>
 }

--- a/src/app/dashboard/end-appointment/page.tsx
+++ b/src/app/dashboard/end-appointment/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+
+import { useSearchParams, useRouter } from 'next/navigation'
+import {
+    Button,
+    Stack,
+    Textarea,
+    Title,
+} from '@mantine/core'
+
+
+export default function Page() {
+    // Hooks
+    const params = useSearchParams()
+    const router = useRouter()
+
+
+    router.prefetch('/dashboard')
+    function saveAndExit() {
+        console.log("Saving and exiting")
+        router.replace('/dashboard')
+    }
+
+    const appointment = params.get("appointment")
+    const patient = params.get("patient")
+    return <Stack>
+        <Title>Appointment Summary</Title>
+        <Textarea placeholder="Patient's main complaints"/>
+        <Textarea placeholder="Conclusions"/>
+        {/* This button should only add tasks when after `Save and Exit` has
+            been pressed */}
+        <Button>Add Follow Up Tasks</Button>
+        <Textarea 
+            label="Patient's notes"
+            placeholder="Notes"
+            autosize
+            minRows={4}
+            maxRows={8}
+        />
+        <Button onClick={saveAndExit}>Save and Exit</Button>
+    </Stack>
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,7 +44,7 @@ function SelectPatient () {
                     query: { patient: "test-patient" }
                 }}>
                     {/* Just for testing */}
-                    <Button fullWidth>Choosen existing patient</Button>
+                    <Button fullWidth>Choose an existing patient</Button>
                 </Link>
             </Column>
         </Group>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import {
+    Title,
+    Group, Stack, Button } from '@mantine/core'
+
+
+function Column(props: { name: string, children: React.ReactNode }) {
+    return <Stack
+        align="stretch"
+        justify="flex-start"
+    >
+        <Title ta="center" order={4}>{props.name}</Title>
+        {props.children}
+    </Stack>
+}
+
+
+function SelectPatient () {
+    return <Stack>
+        <Title ta="center">Select a Patient</Title>
+        <Group grow align="stretch" justify="flex-start">
+            <Column name="With Existing Appointment">
+                <Link prefetch={true} href={{
+                    pathname: "/dashboard/view-patient",
+                    query: {
+                        patient: 'test-patient',
+                        appointment: 'test-appointment',
+                    }
+                }}>
+                    {/* Just for testing */}
+                    <Button fullWidth>Choose test appointment</Button>
+                </Link>
+            </Column>
+            <Column name="Without an Appointment">
+                <Link prefetch={true} href="/dashboard/create-patient">
+                    {/* Just for testing */}
+                    <Button fullWidth>New patient</Button>
+                </Link>
+                <Link prefetch={true} href={{
+                    pathname: "/dashboard/create-appointment",
+                    query: { patient: "test-patient" }
+                }}>
+                    {/* Just for testing */}
+                    <Button fullWidth>Choosen existing patient</Button>
+                </Link>
+            </Column>
+        </Group>
+    </Stack>
+}
+
+
+// The main component of the dashboard page
+export default function DashboardPage(): JSX.Element {
+    return <SelectPatient/>
+}

--- a/src/app/dashboard/view-patient/page.tsx
+++ b/src/app/dashboard/view-patient/page.tsx
@@ -1,15 +1,28 @@
 'use client'
 
 
+import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import {
+    Button,
+    Title,
+    Stack,
+} from '@mantine/core'
 
 
 export default function Page() {
     const params = useSearchParams()
     const appointment = params.get("appointment")
     const patient = params.get("patient")
-    return <div>
-        <h4>Appointment: {appointment}</h4>
-        <h4>Patient: {patient}</h4>
-    </div>
+    return <Stack>
+        <Title>Appointment for Patient</Title>
+        <Title order={4}>Appointment: {appointment}</Title>
+        <Title order={4}>Patient: {patient}</Title>
+        <Link prefetch={true} href={{
+            pathname: "/dashboard/end-appointment",
+            query: { patient, appointment }
+        }}>
+            <Button>End Appointment</Button>
+        </Link>
+    </Stack>
 }

--- a/src/app/dashboard/view-patient/page.tsx
+++ b/src/app/dashboard/view-patient/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+
+import { useSearchParams } from 'next/navigation'
+
+
+export default function Page() {
+    const params = useSearchParams()
+    const appointment = params.get("appointment")
+    const patient = params.get("patient")
+    return <div>
+        <h4>Appointment: {appointment}</h4>
+        <h4>Patient: {patient}</h4>
+    </div>
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import { CalendarEvent, Home2 } from 'tabler-icons-react'
 import Link from 'next/link'
 import './NavBar.css'
 import { FaStethoscope, FaRegUser, FaListCheck } from 'react-icons/fa6'
+import { LuAlignEndHorizontal } from 'react-icons/lu'
 import { usePathname } from 'next/navigation'
 
 const Navbar: React.FC<{ opened: boolean, toggle: () => void }> = ({
@@ -17,6 +18,11 @@ const Navbar: React.FC<{ opened: boolean, toggle: () => void }> = ({
       href: '/',
       label: 'Home',
       icon: <Home2 size="20px"/>
+    },
+    {
+      href: '/dashboard',
+      label: 'Dashboard',
+      icon: <LuAlignEndHorizontal size="20px"/>
     },
     {
       href: '/patients',


### PR DESCRIPTION
This fun, innovative and chillaxed PR adds a route for the dashboard page, with some buttons to navigate to some sub-routes. All of these are demo pages just to understand how the pages will look like and follow one from another.

Closes TekClinic/backlog#79 !